### PR TITLE
Scala 3.0.0 final

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.0.0-RC2, 3.0.0-RC3, 2.12.13, 2.13.5]
+        scala: [3.0.0, 2.12.13, 2.13.5]
         java:
           - adopt@1.8
           - adopt@1.11

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ ThisBuild / publishFullName := "Daniel Spiewak"
 
 ThisBuild / strictSemVer := false
 
-ThisBuild / crossScalaVersions := Seq("3.0.0-RC2", "3.0.0-RC3", "2.12.13", "2.13.5")
+ThisBuild / crossScalaVersions := Seq("3.0.0", "2.12.13", "2.13.5")
 
 ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@1.11", "adopt@1.14", "graalvm-ce-java8@20.2.0")
 
@@ -45,5 +45,5 @@ lazy val core = crossProject(JSPlatform, JVMPlatform).in(file("core"))
   .settings(dottyLibrarySettings)
   .settings(
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-free" % "2.6.0",
-      "org.typelevel" %%% "cats-mtl"  % "1.2.0"))
+      "org.typelevel" %%% "cats-free" % "2.6.1",
+      "org.typelevel" %%% "cats-mtl"  % "1.2.1"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("com.codecommit"     % "sbt-spiewak-sonatype"     % "0.20.4")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.5.1")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.5")


### PR DESCRIPTION
sbt-spiewak depends on an outdated sbt-dotty version, which is why it needs to be added here